### PR TITLE
Change role from 'level.dimmer' to 'value.interval' for brightness-duration

### DIFF
--- a/main.js
+++ b/main.js
@@ -1203,7 +1203,7 @@ function createNanoleafDevice(deviceInfo, callback) {
 				max: 60,
 				read: true,
 				write: true,
-				role: 'level.dimmer',
+				role: 'value.interval',
 				desc: 'Brightness transition duration in seconds',
 			},
 			native: {},


### PR DESCRIPTION
Elsewise the `brightness-duration` is taken instead of `brightness` for Dimmer in Alexa