### PR TITLE
fix dying commandQueue due to socket timeouts

### DIFF
--- a/lib/nanoleaf-aurora-api.js
+++ b/lib/nanoleaf-aurora-api.js
@@ -6,8 +6,11 @@ const { EventSource } = require('eventsource');
 const timeout = 2000;
 
 const httpAgent = new http.Agent({
-	keepAlive: true,
-	maxSockets: 1,
+	keepAlive: true, // Socket-Reuse (gegen Handle-Erschöpfung)
+	maxSockets: 50, // enough slots per host
+	maxFreeSockets: 10, // pool idle sockets
+	keepAliveMsecs: 5000, // TCP keep-alive ping every 5s
+	timeout: 60000, // inactive socket timeout
 });
 
 const AuroraApi = (module.exports = function (options) {

--- a/lib/nanoleaf-aurora-api.js
+++ b/lib/nanoleaf-aurora-api.js
@@ -110,6 +110,10 @@ const AuroraApi = (module.exports = function (options) {
 			request.on('error', function (error) {
 				reject(error);
 			});
+
+			request.on('timeout', () => {
+				request.destroy();
+			});
 		});
 	};
 


### PR DESCRIPTION
- add a timeout to http.request. in case of a http timeout the commandQueue died
- fix reason for http timeouts in SSE mode